### PR TITLE
Better error messages

### DIFF
--- a/backend/src/main/java/com/oskarwiedeweg/cloudwork/auth/dto/LoginDto.java
+++ b/backend/src/main/java/com/oskarwiedeweg/cloudwork/auth/dto/LoginDto.java
@@ -6,10 +6,10 @@ import lombok.Data;
 @Data
 public class LoginDto {
 
-    @NotBlank
+    @NotBlank(message = "Is empty.")
     private final String username;
 
-    @NotBlank
+    @NotBlank(message = "Is empty.")
     private final String password;
 
 }

--- a/backend/src/main/java/com/oskarwiedeweg/cloudwork/auth/dto/RegisterDto.java
+++ b/backend/src/main/java/com/oskarwiedeweg/cloudwork/auth/dto/RegisterDto.java
@@ -3,21 +3,28 @@ package com.oskarwiedeweg.cloudwork.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class RegisterDto {
 
-    @NotBlank
-    @Pattern(regexp = "([A-Za-z0-9-._]{3,})")
+    @NotBlank(message = "Is empty.")
+    @Pattern(regexp = "([A-Za-z0-9-._])", message = "Other character than A-Z, a-z, 0-9, -, ., or _")
+    @Size(min = 5, message = "Less characters than 5.")
     private final String username;
 
-    @Email
-    @NotBlank
+    @Email(message = "Invalid email.")
+    @NotBlank(message = "Is empty.")
     private final String email;
 
-    @NotBlank
-    @Pattern(regexp = "((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])).{8,}")
+    @NotBlank(message = "Is empty.")
+    @Pattern.List(value = {
+            @Pattern(regexp = "(?=.*[A-Z])", message = "No capital letter."),
+            @Pattern(regexp = "(?=.*[a-z])", message = "No lowercase letter."),
+            @Pattern(regexp = "(?=.*\\d)", message = "No digit.")
+    })
+    @Size(min = 8, message = "Less thant 8 characters.")
     private final String password;
 
 }

--- a/backend/src/main/java/com/oskarwiedeweg/cloudwork/error/GlobalErrorHandler.java
+++ b/backend/src/main/java/com/oskarwiedeweg/cloudwork/error/GlobalErrorHandler.java
@@ -6,13 +6,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @ControllerAdvice
@@ -38,6 +44,19 @@ public class GlobalErrorHandler {
         return construct(HttpStatus.FORBIDDEN, throwable.getMessage());
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorDto> handleError(MethodArgumentNotValidException throwable) {
+        Map<String, List<String>> errors = new HashMap<>();
+        for (FieldError fieldError : throwable.getBindingResult().getFieldErrors()) {
+            List<String> list = errors.getOrDefault(fieldError.getField(), new ArrayList<>());
+
+            list.add(fieldError.getDefaultMessage());
+
+            errors.put(fieldError.getField(), list);
+        }
+
+        return construct(HttpStatus.BAD_REQUEST, errors);
+    }
 
     private ResponseEntity<ErrorDto> construct(HttpStatusCode statusCode, Object error) {
         return ResponseEntity.status(statusCode).body(new ErrorDto(

--- a/backend/src/main/java/com/oskarwiedeweg/cloudwork/feed/dto/CreatePostDto.java
+++ b/backend/src/main/java/com/oskarwiedeweg/cloudwork/feed/dto/CreatePostDto.java
@@ -2,16 +2,21 @@ package com.oskarwiedeweg.cloudwork.feed.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class CreatePostDto {
 
-    @NotBlank
-    @Pattern(regexp = "([a-zA-Z0-9. ?,-]).{5,30}")
+    @NotBlank(message = "Is empty.")
+    @Pattern(regexp = "([A-Za-z0-9-._ ])", message = "Other character than A-Z, a-z, 0-9, -, ., or _")
+    @Size(min = 5, message = "Less than 5 characters.")
+    @Size(min = 30, message = "More than 30 characters.")
     private final String title;
 
-    @Pattern(regexp = "([a-zA-Z0-9. ?,-]).{0,500}")
+    @NotBlank(message = "Is empty.")
+    @Pattern(regexp = "([A-Za-z0-9-._ ])", message = "Other character than A-Z, a-z, 0-9, -, ., or _")
+    @Size(min = 5000, message = "More than 5000 characters.")
     private final String description;
 
 }


### PR DESCRIPTION
Include validation error messages in response body.

Label all validation constraints.

Every validation error message returns the error, **not** the valid form.

E.g.:
Message: "Less than 5 characters." says that there are less than 5 characters but there should be more.
